### PR TITLE
Trim down gemspec files to bare necessities

### DIFF
--- a/whois-parser.gemspec
+++ b/whois-parser.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3"
 
   s.require_paths    = %w( lib )
-  s.files            = `git ls-files`.split("\n")
-  s.test_files       = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files            = Dir["lib/**/*", "LICENSE.txt", "CHANGELOG.md", "README.md", ".yardopts"]
   s.extra_rdoc_files = %w( LICENSE.txt .yardopts )
 
   s.add_dependency "whois", ">= 4.1.0"


### PR DESCRIPTION
Hello, was working on optimizing some pipelines in my app and noticed that one of the largest gem size contributors was

```
7936	vendor/ruby/3.4.0/bundler/gems/whois-parser-66fbb9ae3548/spec/fixtures
...
13184	vendor/ruby/3.4.0/bundler/gems/whois-parser-66fbb9ae3548/spec
...
16112	vendor/ruby/3.4.0/bundler/gems/whois-parser-66fbb9ae3548
```

Two things:

1. `git ls-files` in the gemspec is expanded at build time (?), an installed gem has an actual list of files inlined there 😄 
2. All files are included instead of just the usual necessities like `lib`. In particular some ~3M characters worth of tests.

I imagine both issues were carried over from the fork. I am also aware the second one doesn't get fixed unless you make a gem release — any chance you could do that?

Thanks